### PR TITLE
UNSAFE_componentWillMount Quick and dirty

### DIFF
--- a/App.js
+++ b/App.js
@@ -59,7 +59,7 @@ export default class App extends React.Component {
     })
 
   }
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.PanResponder = PanResponder.create({
 
       onStartShouldSetPanResponder: (evt, gestureState) => true,


### PR DESCRIPTION
An quick and dirty update to don't warning with React 16.9.
Maybe there is an better way to solve this, but, as I tougth, this is only quick and dirty